### PR TITLE
Camera44

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ log/*.log
 tmp/
 public/system/images/
 public/system/avatars/
-
+.idea/
 Library/
 Temp/
 Obj/

--- a/Assets/Scenes/Cassiopeia.unity
+++ b/Assets/Scenes/Cassiopeia.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 0.02200779, g: 0.009937315, b: 0.035911307, a: 1}
+  m_IndirectSpecularColor: {r: 0.015151451, g: 0.004667077, b: 0.028175348, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -4253,6 +4253,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5137222419336618003, guid: f8873d4e56b7a43ffbe17a32ad320b7a,
+        type: 3}
+      propertyPath: m_Interpolate
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5137222419336618005, guid: f8873d4e56b7a43ffbe17a32ad320b7a,
         type: 3}
@@ -8554,6 +8559,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3965524033634280000, guid: 5af2148d413b4438e81dae883bf23173,
+        type: 3}
+      propertyPath: m_Interpolate
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4943265309136642250, guid: 5af2148d413b4438e81dae883bf23173,
         type: 3}
       propertyPath: m_Enabled
@@ -8644,6 +8654,16 @@ PrefabInstance:
       propertyPath: topViewCamPos
       value: 
       objectReference: {fileID: 1391387692}
+    - target: {fileID: 8377187791607531545, guid: 5af2148d413b4438e81dae883bf23173,
+        type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 1148804705}
+    - target: {fileID: 8377187791607531545, guid: 5af2148d413b4438e81dae883bf23173,
+        type: 3}
+      propertyPath: minimumDistanceFromTarget
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 8377187791607531547, guid: 5af2148d413b4438e81dae883bf23173,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Orbit.cs
+++ b/Assets/Scripts/Orbit.cs
@@ -23,11 +23,8 @@ public class Orbit : MonoBehaviour
     private Collider _player;
     private Transform _self;
     private bool _launchBegan;
-
     public static event Action OnOrbitStart;
     public static event Action OnOrbitStop;
-
-    public static event Action OnSlingshotLaunch;
 
     private void Start()
     {
@@ -134,7 +131,6 @@ public class Orbit : MonoBehaviour
     /// </summary>
     private void Slingshot()
     {
-        OnSlingshotLaunch?.Invoke();
         _launchBegan = false;
         _player.gameObject.transform.SetParent(null);
         speed = _normalSpeed;

--- a/Assets/Scripts/Orbit.cs
+++ b/Assets/Scripts/Orbit.cs
@@ -24,10 +24,10 @@ public class Orbit : MonoBehaviour
     private Transform _self;
     private bool _launchBegan;
 
-    public static event Action OnOrbit;
-    public static event Action OffOrbit;
+    public static event Action OnOrbitStart;
+    public static event Action OnOrbitStop;
 
-    public static event Action OnSlingShot;
+    public static event Action OnSlingshotLaunch;
 
     private void Start()
     {
@@ -88,11 +88,11 @@ public class Orbit : MonoBehaviour
             // player can orbit only if the star is lit
             if (!_self.parent.parent.GetComponent<Star>().isCreated) return;
 
-            OnOrbit?.Invoke();
-
             _player = other;
             _self.LookAt(other.transform.position);
             other.gameObject.transform.SetParent(transform);
+            
+            OnOrbitStart?.Invoke();
             InvokeRepeating(nameof(AdjustRotation), 1.0f, 1.0f);
         }
         
@@ -107,8 +107,7 @@ public class Orbit : MonoBehaviour
         
         if (!other.gameObject.tag.Contains("|Player|")) return;
 
-        OffOrbit?.Invoke();
-
+        OnOrbitStop?.Invoke();
         CancelInvoke(nameof(AdjustRotation));
     }
 
@@ -121,8 +120,6 @@ public class Orbit : MonoBehaviour
     /// </remarks>
     private void SlingshotStart()
     {
-
-        
         _launchBegan = true;
         CancelInvoke(nameof(AdjustRotation));
         _player.gameObject.transform.SetParent(null);
@@ -137,7 +134,7 @@ public class Orbit : MonoBehaviour
     /// </summary>
     private void Slingshot()
     {
-        OnSlingShot?.Invoke();
+        OnSlingshotLaunch?.Invoke();
         _launchBegan = false;
         _player.gameObject.transform.SetParent(null);
         speed = _normalSpeed;

--- a/Assets/Scripts/ThirdPersonCamera.cs
+++ b/Assets/Scripts/ThirdPersonCamera.cs
@@ -40,7 +40,7 @@ public class ThirdPersonCamera : MonoBehaviour
         var yAxisInput = Input.GetAxis("Mouse Y");
 
         var distanceToTarget = Vector3.Distance(_mainCamera.position, _cameraTarget.position);
-        if (Math.Abs(distanceToTarget - minimumDistanceFromTarget) > 1.0f)
+        if (Math.Abs(distanceToTarget - minimumDistanceFromTarget) > 0.1f * minimumDistanceFromTarget)
         {
             var currentCameraPosition = _mainCamera.position;
             

--- a/Assets/Scripts/ThirdPersonCamera.cs
+++ b/Assets/Scripts/ThirdPersonCamera.cs
@@ -3,28 +3,17 @@ using UnityEngine;
 
 public class ThirdPersonCamera : MonoBehaviour
 {
-    public Transform player;                      // the player to look at
-    private Transform _mainCamera;                  // camera itself
+    public Transform player;
+    private Transform _mainCamera;
 
     public float minimumDistanceFromTarget = 4;
     public float maximumRotationSpeed = 1.8f;
     public float cameraFollowDelay = 0.2f;
 
-    public float smoothSpeed = 0.125f;
-
     private Transform _cameraTarget;
     private Vector3 _currentCameraVelocity = Vector3.zero;
 
-    private float _currentX;
-    private float _currentY;
-
-    private bool _orbitDetected;
-    private bool _firstTimeOrbit;
-
     private bool _levelCleared;
-
-    private bool _onSlingShot;
-
     public Transform topViewCamPos;
 
     /// <summary>
@@ -37,7 +26,6 @@ public class ThirdPersonCamera : MonoBehaviour
         
         Orbit.OnOrbitStart += OnOrbitStart;
         Orbit.OnOrbitStop += OnOrbitStop;
-        Orbit.OnSlingshotLaunch += OnSlingshotLaunch;
         ClearLevel.OnLevelClear += OnLevelClear;
 
         var dir = new Vector3(0, 0, -10.0f);
@@ -90,36 +78,14 @@ public class ThirdPersonCamera : MonoBehaviour
         _mainCamera.LookAt(_cameraTarget);
         
         //TODO: Refactor this implementation to use IsometricCamera when that feature is implemented.
-        if (_levelCleared)
-        {
-            var desiredPosition = topViewCamPos.position;
-            transform.position = Vector3.Lerp(transform.position, desiredPosition, 0.0125f);
+        if (!_levelCleared) return;
+        var desiredPosition = topViewCamPos.position;
+        transform.position = Vector3.Lerp(transform.position, desiredPosition, 0.0125f);
 
-            var newRot = Quaternion.Euler(90, -45, -500); 
-            transform.rotation = Quaternion.Slerp(transform.rotation, newRot, 0.0125f);
-        } 
-        else
-        {
-            if (!_onSlingShot) return;
-            // look at the left side when player slingshots
-            var desiredPosition = player.position - player.right * 10;
-                
-            // smooth following
-            var smoothPosition = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed * Time.deltaTime);
-            transform.position = smoothPosition;
-
-            _mainCamera.LookAt(player);
-
-            // TODO: still need to test this code
-//             // position the camera behind the player by "distance"
-//             var dir = new Vector3(0, 0, -distance);
-//             var rotation = Quaternion.Euler(_currentY, _currentX, 0);
-//             // smooth following
-//             var desiredPosition = _target.position;
-//             var smoothPosition = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed);
-//             transform.position = smoothPosition + rotation * dir;
-        }
+        var newRot = Quaternion.Euler(90, -45, -500); 
+        transform.rotation = Quaternion.Slerp(transform.rotation, newRot, 0.0125f);
         
+        //TODO: Add slingshot camera effects.
     }
 
     private void OnOrbitStart()
@@ -139,18 +105,4 @@ public class ThirdPersonCamera : MonoBehaviour
         _levelCleared = true;
     }
 
-    private void OnSlingshotLaunch()
-    {
-        _onSlingShot = true;
-        Debug.Log("OnSlingShot");
-        Invoke(nameof(OffSlingShot), 2);
-
-    }
-
-    private void OffSlingShot()
-    {
-        _onSlingShot = false;
-        Debug.Log("OnSlingShot");
-    }
-    
 }

--- a/Assets/Scripts/ThirdPersonCamera.cs
+++ b/Assets/Scripts/ThirdPersonCamera.cs
@@ -6,7 +6,7 @@ public class ThirdPersonCamera : MonoBehaviour
     public Transform player;                      // the player to look at
     private Transform _mainCamera;                  // camera itself
 
-    public float minimumDistanceFromTarget = 0.8f;
+    public float minimumDistanceFromTarget = 4;
     public float maximumRotationSpeed = 1.8f;
     public float cameraFollowDelay = 0.2f;
 

--- a/Assets/Scripts/ThirdPersonCamera.cs
+++ b/Assets/Scripts/ThirdPersonCamera.cs
@@ -11,7 +11,7 @@ public class ThirdPersonCamera : MonoBehaviour
     public float smoothSpeed = 0.125f;
     public float distance = 0.8f;
     public float smoothTime = 0.3F;
-    private Vector3 velocity = Vector3.zero;
+    private Vector3 _velocity = Vector3.zero;
 
     private float _currentX;
     private float _currentY;
@@ -79,7 +79,6 @@ public class ThirdPersonCamera : MonoBehaviour
 
                 if (_firstTimeOrbit)
                 {
-                    
                     var smoothPosition = Vector3.Lerp(transform.position, transform.position + new Vector3(-distance, 0, -distance), smoothSpeed * Time.deltaTime);
                     transform.position = smoothPosition;
 
@@ -92,7 +91,7 @@ public class ThirdPersonCamera : MonoBehaviour
             }
             else if (_onSlingShot)
             {
-                // look at the left side while player slingshotting
+                // look at the left side when player slingshots
                 var desiredPosition = character.position - character.right * 10;
                 
                 // smooth following
@@ -104,7 +103,6 @@ public class ThirdPersonCamera : MonoBehaviour
 
             else
             {
-
                 cam.LookAt(character);
                 // smooth following
                 var desiredPosition = character.position;
@@ -112,7 +110,7 @@ public class ThirdPersonCamera : MonoBehaviour
                 transform.position = smoothPosition;
 
                 // prevent camera shaking
-                Vector3 newPosition = Vector3.SmoothDamp(transform.position, transform.position + rotation * dir, ref velocity, smoothTime);
+                var newPosition = Vector3.SmoothDamp(transform.position, transform.position + rotation * dir, ref _velocity, smoothTime);
                 transform.position = newPosition;
             }
 
@@ -162,6 +160,5 @@ public class ThirdPersonCamera : MonoBehaviour
         _onSlingShot = false;
         Debug.Log("OnSlingShot");
     }
-
-
+    
 }

--- a/Assets/Scripts/ThirdPersonPlayer.cs
+++ b/Assets/Scripts/ThirdPersonPlayer.cs
@@ -28,6 +28,7 @@ public class ThirdPersonPlayer : MonoBehaviour
         CameraSwitch.OnMapSwitch += SetMapActive;
     }
 
+    
     private static void SetMapActive(bool mapActive)
     {
         _mapActive = mapActive;
@@ -40,6 +41,7 @@ public class ThirdPersonPlayer : MonoBehaviour
         collectDustSound = collectDustSoundContainer.GetComponent<AudioSource>();
     }
 
+    
     public void OnTriggerEnter(Collider collision)
     {
         // TODO: Move me to the collect stardust script.
@@ -49,19 +51,52 @@ public class ThirdPersonPlayer : MonoBehaviour
         }
     }
 
-
+    /// <summary>
+    /// FixedUpdate is called for every physics frame (when player is moving)
+    /// </summary>
     private void FixedUpdate()
     {
         if (_mapActive) return;
+        Move();
+
+        // handle player rotation for movement if the player is not at the same location as the camera,
+        if (_direction != Vector3.zero)
+        {
+            HandleRotation();
+        }
+        // TODO: add the UI for stardust count back to canvas
+        //stardustcount.text = "Stardust: " + stardust;
+    }
+
+    
+    private void Move()
+    {
+        // x is left and right
+        // y is in and out
         var xAxis = Input.GetAxisRaw("Horizontal");
         var yAxis = Input.GetAxisRaw("Vertical");
 
-        _direction = new Vector3(xAxis, 0f, yAxis);
-        _direction = _direction.normalized;
+        _direction = new Vector3(xAxis, 0f, yAxis).normalized;
 
+        // Convert direction from local to world relative to camera
         _body.transform.Translate(cam.transform.TransformDirection(_direction) * speed, Space.World);
 
-        // stardustcount.text = "Stardust: " + stardust;
+    }
+
+    
+    /// <summary>
+    /// Rotate the player to face the direction of their movement.
+    /// This function will be called only when player is moving.
+    /// </summary>
+    private void HandleRotation()
+    {
+        // determines which angle that the camera is facing
+        var targetRotation = Mathf.Atan2(_direction.x, _direction.z) * Mathf.Rad2Deg + cam.transform.eulerAngles.y;
+        // determines which angle that player should be facing
+        var lookAt = Quaternion.Slerp(transform.rotation,
+            Quaternion.Euler(0, targetRotation, 0),
+            0.5f);
+        _body.rotation = lookAt;
     }
     
 }

--- a/Assets/Scripts/ThirdPersonPlayer.cs
+++ b/Assets/Scripts/ThirdPersonPlayer.cs
@@ -52,47 +52,16 @@ public class ThirdPersonPlayer : MonoBehaviour
 
     private void FixedUpdate()
     {
-
-        if (!_mapActive)
-        {
-            Move();
-        }
-
-        // if the mc is not at the same location as the camera,
-        // handle camera rotation
-        if (_direction != Vector3.zero)
-        {
-            HandleRotation();
-        }
-        stardustcount.text = "Stardust: " + stardust;
-    }
-
-    private void Move()
-    {
-        // x is left and right
-        // y is in and out
+        if (_mapActive) return;
         var xAxis = Input.GetAxisRaw("Horizontal");
         var yAxis = Input.GetAxisRaw("Vertical");
 
         _direction = new Vector3(xAxis, 0f, yAxis);
-
         _direction = _direction.normalized;
-
-        // Camera.main to cam
-        // Convert direction from local to world relative to camera
 
         _body.transform.Translate(cam.transform.TransformDirection(_direction) * speed, Space.World);
 
+        // stardustcount.text = "Stardust: " + stardust;
     }
-
-    private void HandleRotation()
-    {
-        // determines which angle that the camera is looking at
-        var targetRotation = Mathf.Atan2(_direction.x, _direction.z) * Mathf.Rad2Deg + cam.transform.eulerAngles.y;
-        var lookAt = Quaternion.Slerp(transform.rotation,
-                                      Quaternion.Euler(0, targetRotation, 0),
-                                      0.5f);
-        _body.rotation = lookAt;
-    }
-
+    
 }


### PR DESCRIPTION
Overhauled the way the camera is handled in an attempt to create a snappier, more responsive camera.

Decoupled the player movement and camera scripts; the player movement script no longer affects the camera.

Removed the camera effects that occur during a slingshot; these should be re-implemented in the future. A TODO has been marked to do so.

Added interpolation to the player and camera in the Cassiopeia scene to reduce stuttering.

This PR will close #44 . Merge when the changes will adequately meet those requirements.