### PR TITLE
Mapicon

### DIFF
--- a/Assets/Scenes/Ursa Minor.unity
+++ b/Assets/Scenes/Ursa Minor.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 0.015121656, g: 0.004663416, b: 0.028162796, a: 1}
+  m_IndirectSpecularColor: {r: 0.015151451, g: 0.004667077, b: 0.028175348, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1758,6 +1758,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cameraOne: {fileID: 283867117}
   cameraTwo: {fileID: 1616016495}
+  mapPlayerPosition: {fileID: 1035806603}
 --- !u!4 &255532832
 Transform:
   m_ObjectHideFlags: 0
@@ -4826,6 +4827,111 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 38256601}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1035806603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1035806607}
+  - component: {fileID: 1035806606}
+  - component: {fileID: 1035806605}
+  - component: {fileID: 1035806604}
+  - component: {fileID: 1035806608}
+  m_Layer: 0
+  m_Name: MapPlayerPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &1035806604
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1035806603}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1035806605
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1035806603}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1035806606
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1035806603}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1035806607
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1035806603}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 100, y: 100, z: 100}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 35
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1035806608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1035806603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbc0ea56dbee2864bbdea0f9e74e54d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1059468733
 GameObject:
   m_ObjectHideFlags: 0
@@ -11166,6 +11272,11 @@ PrefabInstance:
       propertyPath: topViewCamPos
       value: 
       objectReference: {fileID: 1391387692}
+    - target: {fileID: 8377187791607531545, guid: 5af2148d413b4438e81dae883bf23173,
+        type: 3}
+      propertyPath: cam
+      value: 
+      objectReference: {fileID: 1687258585}
     - target: {fileID: 8377187791607531547, guid: 5af2148d413b4438e81dae883bf23173,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/Ursa Minor.unity
+++ b/Assets/Scenes/Ursa Minor.unity
@@ -1737,6 +1737,7 @@ GameObject:
   m_Component:
   - component: {fileID: 255532832}
   - component: {fileID: 255532831}
+  - component: {fileID: 255532833}
   m_Layer: 0
   m_Name: MapScript
   m_TagString: '|MapScript|'
@@ -1773,6 +1774,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &255532833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 255532830}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3df1bd7b70af9c45a4a5a758c9d1712, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!95 &260018404 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 2777209796985971427, guid: 399b4fc82195942069d447f4154576f1,
@@ -7128,10 +7141,20 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 0.46396303
       objectReference: {fileID: 0}
+    - target: {fileID: 1146195323054460968, guid: 5c309b70a7f0d472eb666f25dde2ed03,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1703217123732974197, guid: 5c309b70a7f0d472eb666f25dde2ed03,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1703217123732974197, guid: 5c309b70a7f0d472eb666f25dde2ed03,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8240559358194348407, guid: 5c309b70a7f0d472eb666f25dde2ed03,
         type: 3}
@@ -7197,6 +7220,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Star 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9007396541691365466, guid: 5c309b70a7f0d472eb666f25dde2ed03,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5c309b70a7f0d472eb666f25dde2ed03, type: 3}

--- a/Assets/Scripts/CameraSwitch.cs
+++ b/Assets/Scripts/CameraSwitch.cs
@@ -5,6 +5,7 @@ public class CameraSwitch : MonoBehaviour {
 
     public GameObject cameraOne;
     public GameObject cameraTwo;
+    public GameObject mapPlayerPosition;
     private static bool _mapActive;
     public static event Action<bool> OnMapSwitch;
     
@@ -14,6 +15,8 @@ public class CameraSwitch : MonoBehaviour {
         cameraOne.SetActive(true);
         cameraTwo.SetActive(false);
         _mapActive = false;
+        //Disable player map position indicator
+        mapPlayerPosition.SetActive(false);
         //Notify ThirdPersonPlayer on map status
         OnMapSwitch?.Invoke(_mapActive);
     }
@@ -62,6 +65,7 @@ public class CameraSwitch : MonoBehaviour {
                 OnMapSwitch?.Invoke(_mapActive);
                 //Time.timeScale = 1f;
                 cameraTwo.SetActive(false);
+                mapPlayerPosition.SetActive(false);
                 break;
             //Set camera position 2 which is map camera
             case 1:
@@ -71,6 +75,7 @@ public class CameraSwitch : MonoBehaviour {
                 OnMapSwitch?.Invoke(_mapActive);
                 //Time.timeScale = 0f;
                 cameraOne.SetActive(false);
+                mapPlayerPosition.SetActive(true);
                 break;
         }
     }

--- a/Assets/Scripts/MapPlayerPosition.cs
+++ b/Assets/Scripts/MapPlayerPosition.cs
@@ -1,17 +1,11 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 public class MapPlayerPosition : MonoBehaviour
 {
     // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
 
     // Update is called once per frame
-    void Update()
+    private void Update()
     {
         FollowPlayer();
     }
@@ -20,6 +14,7 @@ public class MapPlayerPosition : MonoBehaviour
     private void FollowPlayer()
     {
         var player = GameObject.FindWithTag("|Player|").transform;
-        transform.position = new Vector3(player.position.x, player.position.y, player.position.z);
+        var position = player.position;
+        transform.position = new Vector3(position.x, position.y, position.z);
     }
 }

--- a/Assets/Scripts/MapPlayerPosition.cs
+++ b/Assets/Scripts/MapPlayerPosition.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MapPlayerPosition : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        FollowPlayer();
+    }
+    
+    //Update mapPlayerPosition with player position
+    private void FollowPlayer()
+    {
+        var player = GameObject.FindWithTag("|Player|").transform;
+        transform.position = new Vector3(player.position.x, player.position.y, player.position.z);
+    }
+}

--- a/Assets/Scripts/MapPlayerPosition.cs.meta
+++ b/Assets/Scripts/MapPlayerPosition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbc0ea56dbee2864bbdea0f9e74e54d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MapStarController.cs
+++ b/Assets/Scripts/MapStarController.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+public class MapStarController : MonoBehaviour
+{
+    private static bool _mapActive;
+    private readonly HashSet<GameObject> _deactivatedStars = new HashSet<GameObject>();
+    
+    private void Start()
+    {
+        CameraSwitch.OnMapSwitch += SetMapActive;
+    }
+
+    private static void SetMapActive(bool mapActive)
+    {
+        _mapActive = mapActive;
+    }
+
+    // Update is called once per frame
+    private void Update()
+    {
+        if (_mapActive)
+        {
+            SetStarVisibility();
+        }
+        else
+        {
+            RevertStarVisibility();
+        }
+    }
+
+    private void SetStarVisibility()
+    {
+        var litStarHashSet = new HashSet<GameObject>();
+        //Disable all the stars, find all stars that are already created
+        try
+        {
+            foreach (var o in GameObject.FindObjectsOfType(typeof(GameObject)))
+            {
+                var go = (GameObject) o;
+                if (!go.tag.Contains("|Star|")) continue;
+                if (go.GetComponent<Star>().isCreated)
+                {
+                    litStarHashSet.Add(go);
+                }
+                else
+                {
+                    _deactivatedStars.Add(go);
+                }
+            }
+        }
+        catch (UnityException)
+        {
+            print("No such tag");
+        }
+        
+        //Remove all adjacent star of lit star from _deactivatedStars
+        foreach (var litStar in litStarHashSet)
+        {
+            _deactivatedStars.Remove(litStar);
+            switch (litStar.name)
+            {
+                case "Star 1":
+                    _deactivatedStars.Remove(GameObject.Find("Star 2"));
+                    break;
+                case "Star 2":
+                    _deactivatedStars.Remove(GameObject.Find("Star 1"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 3"));
+                    break;
+                case "Star 3":
+                    _deactivatedStars.Remove(GameObject.Find("Star 2"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 4"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 5"));
+                    break;
+                case "Star 4":
+                    _deactivatedStars.Remove(GameObject.Find("Star 3"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 5"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 7"));
+                    break;
+                case "Star 5":
+                    _deactivatedStars.Remove(GameObject.Find("Star 3"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 4"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 6"));
+                    break;
+                case "Star 6":
+                    _deactivatedStars.Remove(GameObject.Find("Star 5"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 7"));
+                    break;
+                case "Star 7":
+                    _deactivatedStars.Remove(GameObject.Find("Star 4"));
+                    _deactivatedStars.Remove(GameObject.Find("Star 6"));
+                    break;
+            }
+        }
+
+        //Disable all stars in _deactivatedStars
+        foreach (var deactivatedStar in _deactivatedStars)
+        {
+            deactivatedStar.SetActive(false);
+        }
+    }
+
+    private void RevertStarVisibility()
+    {
+        foreach (var deactivatedStar in _deactivatedStars)
+        {
+            deactivatedStar.SetActive(true);
+        }
+    }
+}

--- a/Assets/Scripts/MapStarController.cs.meta
+++ b/Assets/Scripts/MapStarController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3df1bd7b70af9c45a4a5a758c9d1712
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -126,7 +126,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 0
+    antiAliasing: 4
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -126,7 +126,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 4
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
PR is for Issue 47

Included in this PR:
-Map will now have a sphere to show the player location when the map view is active
-Only "lit" star and unlit star adjacent to lit star will show on the map view.
-Currently only implemented for Ursa Minor, will have to re-implement adjacent star switch statement for Cassiopeia when we finalize the Cassiopeia scene. 
-Used Rider IDE to fix any code style issues, please let me know if I missed anything.
