### PR TITLE
added conditional stardust boost

### DIFF
--- a/Assets/Scenes/Ursa Minor.unity
+++ b/Assets/Scenes/Ursa Minor.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 0.015121656, g: 0.004663416, b: 0.028162796, a: 1}
+  m_IndirectSpecularColor: {r: 0.015151451, g: 0.004667077, b: 0.028175348, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -371,6 +371,18 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 921745524}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &49386038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 49386037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c0e866688eeb3c34f90bdbf03cfc5649, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &49386043
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4619,7 +4631,7 @@ PrefabInstance:
     - target: {fileID: 5137222419336618005, guid: f8873d4e56b7a43ffbe17a32ad320b7a,
         type: 3}
       propertyPath: stardust
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5137222419336618005, guid: f8873d4e56b7a43ffbe17a32ad320b7a,
         type: 3}
@@ -11166,6 +11178,11 @@ PrefabInstance:
       propertyPath: topViewCamPos
       value: 
       objectReference: {fileID: 1391387692}
+    - target: {fileID: 8377187791607531545, guid: 5af2148d413b4438e81dae883bf23173,
+        type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 1148804705}
     - target: {fileID: 8377187791607531547, guid: 5af2148d413b4438e81dae883bf23173,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Boost.cs
+++ b/Assets/Scripts/Boost.cs
@@ -1,14 +1,24 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 public class Boost : MonoBehaviour
 {
-    // Update is called once per frame
+    private ThirdPersonPlayer _playerScript;
+    private float _normalSpeed;
+    private float _boostSpeed;
+
+    private void Start()
+    {
+        _playerScript = GameObject.FindWithTag("|Player|").GetComponent<ThirdPersonPlayer>();
+        _normalSpeed = _playerScript.speed;
+        _boostSpeed = _normalSpeed * 3;
+    }
+
     void Update()
     {
-        var playerScript = GameObject.FindWithTag("|Player|").GetComponent<ThirdPersonPlayer>();
-        if (playerScript.stardust >= 3)
+        if (_playerScript.stardust >= 3)
         {
-            playerScript.speed = Input.GetButton("Jump") ? 1.3f : 0.6f;
+            _playerScript.speed = Input.GetButton("Jump") ? _boostSpeed : _normalSpeed;
         }
     }
 }

--- a/Assets/Scripts/Boost.cs
+++ b/Assets/Scripts/Boost.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+public class Boost : MonoBehaviour
+{
+    // Update is called once per frame
+    void Update()
+    {
+        var playerScript = GameObject.FindWithTag("|Player|").GetComponent<ThirdPersonPlayer>();
+        if (playerScript.stardust >= 3)
+        {
+            playerScript.speed = Input.GetButton("Jump") ? 1.3f : 0.6f;
+        }
+    }
+}

--- a/Assets/Scripts/Boost.cs.meta
+++ b/Assets/Scripts/Boost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0e866688eeb3c34f90bdbf03cfc5649
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Reopened PR from the correct branch this time.

Hold "Jump" to boost.
Current boost implementation is similar to the "sprint" mechanic, hold to boost, let go to return to normal speed.
Current player speed is 0.6 and boost to 1.3
Currently set to only be able to boost with 3 or more stardust.
Checked code using Rider IDE.